### PR TITLE
Add xlrd dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mintos_report
 produces report pdfs for finished investments on mintos.com
 
-# libraries needed: pandas, matplotlib, numpy
+# libraries needed: pandas, matplotlib, numpy, xlrd
 
 1. you need an account on mintos.com to use the script
 2. go on https://www.mintos.com/en/my-investments/finished-investments


### PR DESCRIPTION
```
Emils-MBP:mintos_report esp$ ./mintos_report.py
Unable to revert mtime: /Library/Fonts
Fontconfig warning: ignoring UTF-8: not a valid region tag
Traceback (most recent call last):
  File "./mintos_report.py", line 22, in <module>
    report    = read_excel("report.xlsx", header=None)      # get content w.o. header
  File "/usr/local/lib/python3.7/site-packages/pandas/util/_decorators.py", line 208, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pandas/io/excel/_base.py", line 310, in read_excel
    io = ExcelFile(io, engine=engine)
  File "/usr/local/lib/python3.7/site-packages/pandas/io/excel/_base.py", line 819, in __init__
    self._reader = self._engines[engine](self._io)
  File "/usr/local/lib/python3.7/site-packages/pandas/io/excel/_xlrd.py", line 20, in __init__
    import_optional_dependency("xlrd", extra=err_msg)
  File "/usr/local/lib/python3.7/site-packages/pandas/compat/_optional.py", line 93, in import_optional_dependency
    raise ImportError(message.format(name=name, extra=extra)) from None
ImportError: Missing optional dependency 'xlrd'. Install xlrd >= 1.0.0 for Excel support Use pip or conda to install xlrd.
```